### PR TITLE
add disambiguation suffixes to overload group pages that conflict

### DIFF
--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchy.swift
@@ -484,13 +484,13 @@ extension PathHierarchy {
         return Array(result) + modules.map { $0.identifier }
     }
 
-    func traverseOverloadedSymbolGroups(observe: (_ id: ResolvedIdentifier, _ overloadedSymbols: [ResolvedIdentifier]) throws -> Void) rethrows {
+    func traverseOverloadedSymbolGroups(observe: (_ id: ResolvedIdentifier, _ kind: String, _ overloadedSymbols: [ResolvedIdentifier]) throws -> Void) rethrows {
         for (id, node) in lookup where node.symbol != nil {
             for disambiguation in node.children.values {
                 for (kind, innerStorage) in disambiguation.storage where innerStorage.count > 1 && SymbolGraph.Symbol.KindIdentifier(identifier: kind).isOverloadableKind {
                     assert(innerStorage.values.allSatisfy { $0.symbol != nil }, "Only symbols should have symbol kind identifiers (\(kind))")
 
-                    try observe(id, innerStorage.values.map(\.identifier))
+                    try observe(id, kind, innerStorage.values.map(\.identifier))
                 }
             }
         }

--- a/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
+++ b/Sources/SwiftDocC/Infrastructure/Link Resolution/PathHierarchyBasedLinkResolver.swift
@@ -59,10 +59,10 @@ final class PathHierarchyBasedLinkResolver {
     }
     
     /// Traverse all symbols of the same kind that have collisions.
-    func traverseOverloadedSymbols(_ observe: (_ parent: ResolvedTopicReference, _ overloadedSymbols: [ResolvedTopicReference]) throws -> Void) rethrows {
-        try pathHierarchy.traverseOverloadedSymbolGroups() { id, overloadedSymbols in
+    func traverseOverloadedSymbols(_ observe: (_ parent: ResolvedTopicReference, _ kind: String, _ overloadedSymbols: [ResolvedTopicReference]) throws -> Void) rethrows {
+        try pathHierarchy.traverseOverloadedSymbolGroups() { id, kind, overloadedSymbols in
             guard let parent = resolvedReferenceMap[id] else { return }
-            try observe(parent, overloadedSymbols.map { resolvedReferenceMap[$0]! })
+            try observe(parent, kind, overloadedSymbols.map { resolvedReferenceMap[$0]! })
         }
     }
     


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://119526432

## Summary

If a group of overloads has the same name as another group of overloads (e.g. instance methods and class methods), their generated topic references will overwrite each other. By adding a suffix that states which symbol kind is represented by an overload group, we can prevent different overload groups from clobbering each other.

## Dependencies

https://github.com/apple/swift-docc/pull/825 (This PR is targeting that branch to only show the changes necessary for this bug)

## Testing

The following code demonstrates this issue:

```swift
public class Something {
    public func something() -> Int { 0 }
    public func something() -> String { "" }

    public static func something() -> Int { 0 }
    public static func something() -> String { "" }
}
```

A doc catalog containing a symbol graph generated from this code is available here: [asdf.docc.zip](https://github.com/QuietMisdreavus/swift-docc/files/14273047/asdf.docc.zip)

Steps:
1. `swift run docc preview --enable-experimental-overloaded-symbol-presentation asdf.docc`
2. Navigate to the `Something` class's page.
3. Ensure that both `func something()` and `static func something()` both have generated overload pages.

## Checklist

Make sure you check off the following items. If they cannot be completed, provide a reason.

- [x] Added tests
- [x] Ran the `./bin/test` script and it succeeded
- [ n/a ] Updated documentation if necessary
